### PR TITLE
automated release notes

### DIFF
--- a/.github/workflows/setversion.yml
+++ b/.github/workflows/setversion.yml
@@ -3,22 +3,9 @@ name: Version and Release Notes
 on: create
 
 jobs:
-  prepare:
-    if: ${{ (github.event.ref_type == 'branch') && startsWith(github.event.ref, 'release-') }}
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.what-version.version }}
-    steps:
-      - id: what-version
-        run: |
-          set -x
-          export VERSION="`echo ${{ github.event.ref }} | sed -e s/release-//g`"
-          echo "::set-output name=version::$VERSION"
-
   set-version:
     if: ${{ (github.event.ref_type == 'branch') && startsWith(github.event.ref, 'release-') }}
     runs-on: ubuntu-latest
-    needs: prepare
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
@@ -28,19 +15,23 @@ jobs:
           java-version: 10
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
+      - id: what-version
+        name: Determine version
+        run: |
+          set -x
+          export VERSION="`echo ${{ github.event.ref }} | sed -e s/release-//g`"
+          echo "::set-output name=version::$VERSION"
       - name: Set version and update readme
         run: |
           set -x
-          echo ${{ needs.prepare.outputs.version }}
-          echo ${{ needs.prepare.steps.what-version.outputs.version }}
-          export VERSION="${{ needs.prepare.outputs.version }}"
+          export VERSION="${{ steps.what-version.outputs.version }}"
           mvn versions:set -DnewVersion=$VERSION --file pom.xml
           mvn versions:set -DnewVersion=$VERSION --file superfields/pom.xml
           sed -i -e s/{VERSION}/$VERSION/g ./README.md
       - name: Create milestone notes
         uses: UnforgivenPL/milestone-notes@v1
         with:
-          match-milestone: ^${{ needs.prepare.outputs.version }}
+          match-milestone: ^${{ steps.what-version.outputs.version }}
           repository: ${{ github.repository }}
           labels: "enhancement, api, bug"
       - name: Format milestone notes

--- a/.github/workflows/setversion.yml
+++ b/.github/workflows/setversion.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - id: what-version
         run: |
+          set -x
           export VERSION="`echo ${{ github.event.ref }} | sed -e s/release-//g`"
           echo "::set-output name=version::$VERSION"
 
@@ -29,6 +30,9 @@ jobs:
           settings-path: ${{ github.workspace }} # location for the settings.xml file
       - name: Set version and update readme
         run: |
+          set -x
+          echo ${{ needs.prepare.outputs.version }}
+          echo ${{ needs.prepare.steps.what-version.outputs.version }}
           export VERSION="${{ needs.prepare.outputs.version }}"
           mvn versions:set -DnewVersion=$VERSION --file pom.xml
           mvn versions:set -DnewVersion=$VERSION --file superfields/pom.xml
@@ -41,10 +45,10 @@ jobs:
           labels: "enhancement, api, bug"
       - name: Format milestone notes
         run: |
-          sed -i -e s/## enhancement/## New features and enhancements/g milestone-notes.md
-          sed -i -e s/## api/## Changes to API/g milestone-notes.md
-          sed -i -e s/## bug/## Bug fixes/g milestone-notes.md
-          sed -i -e s/^$/(nothing reported)/g milestone-notes.md
+          sed -i -e "s/## enhancement/## New features and enhancements/g" milestone-notes.md
+          sed -i -e "s/## api/## Changes to API/g" milestone-notes.md
+          sed -i -e "s/## bug/## Bug fixes/g" milestone-notes.md
+          sed -i -e "s/^$/(nothing reported)/g" milestone-notes.md
       - name: Update release notes
         run: |
           cat milestone-notes.md superfields/release-notes.md > superfields/release-notes.md.new

--- a/.github/workflows/setversion.yml
+++ b/.github/workflows/setversion.yml
@@ -42,7 +42,7 @@ jobs:
           sed -i -e "s/^$/(nothing reported)/g" milestone-notes.md
       - name: Update release notes
         run: |
-          echo -e "\n" | cat milestone-notes.md superfields/release-notes.md > superfields/release-notes.md.new
+          echo -e "\n" | cat milestone-notes.md - superfields/release-notes.md > superfields/release-notes.md.new
           mv superfields/release-notes.md.new superfields/release-notes.md
       - name: Remove milestone notes
         run: rm milestone-notes.md

--- a/.github/workflows/setversion.yml
+++ b/.github/workflows/setversion.yml
@@ -1,13 +1,24 @@
-name: Set Version
+name: Version and Release Notes
 
 on: create
 
 jobs:
-  set_version:
+  prepare:
     if: ${{ (github.event.ref_type == 'branch') && startsWith(github.event.ref, 'release-') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.what-version.version }}
+    steps:
+      - id: what-version
+        run: |
+          export VERSION="`echo ${{ github.event.ref }} | sed -e s/release-//g`"
+          echo "::set-output name=version::$VERSION"
 
+  set-version:
+    if: ${{ (github.event.ref_type == 'branch') && startsWith(github.event.ref, 'release-') }}
+    runs-on: ubuntu-latest
+    needs: prepare
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 10
@@ -16,14 +27,32 @@ jobs:
           java-version: 10
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
-      - name: Set version
+      - name: Set version and update readme
         run: |
-          export VERSION="`echo ${{ github.event.ref }} | sed -e s/release-//g`"
+          export VERSION="$ {{ needs.prepare.outputs.version }}"
           mvn versions:set -DnewVersion=$VERSION --file pom.xml
           mvn versions:set -DnewVersion=$VERSION --file superfields/pom.xml
           sed -i -e s/{VERSION}/$VERSION/g ./README.md
+      - name: Create milestone notes
+        uses: UnforgivenPL/milestone-notes@v1
+        with:
+          match-milestone: ^${{ needs.prepare.outputs.version }}
+          repository: ${{ github.repository }}
+          labels: "enhancement, api, bug"
+      - name: Format milestone notes
+        run: |
+          sed -i -e s/## enhancement/## New features and enhancements/g milestone-notes.md
+          sed -i -e s/## api/## Changes to API/g milestone-notes.md
+          sed -i -e s/## bug/## Bug fixes/g milestone-notes.md
+          sed -i -e s/^$/(nothing reported)/g milestone-notes.md
+      - name: Update release notes
+        run: |
+          cat milestone-notes.md superfields/release-notes.md > superfields/release-notes.md.new
+          mv superfields/release-notes.md.new superfields/release-notes.md
+      - name: Remove milestone notes
+        run: rm milestone-notes.md
       - name: Push changes
         uses: stefanzweifel/git-auto-commit-action@v4.1.6
         with:
-          commit_message: "(bot) setting version for branch ${{ github.event.ref }}"
+          commit_message: "(bot) release notes for version ${{ needs.prepare.output.version }}"
           branch: ${{ github.event.ref }}

--- a/.github/workflows/setversion.yml
+++ b/.github/workflows/setversion.yml
@@ -49,5 +49,5 @@ jobs:
       - name: Push changes
         uses: stefanzweifel/git-auto-commit-action@v4.1.6
         with:
-          commit_message: "(bot) release notes for version ${{ needs.prepare.output.version }}"
+          commit_message: "(bot) version and release notes updated to ${{ steps.what-version.outputs.version }}"
           branch: ${{ github.event.ref }}

--- a/.github/workflows/setversion.yml
+++ b/.github/workflows/setversion.yml
@@ -42,7 +42,7 @@ jobs:
           sed -i -e "s/^$/(nothing reported)/g" milestone-notes.md
       - name: Update release notes
         run: |
-          cat milestone-notes.md superfields/release-notes.md > superfields/release-notes.md.new
+          echo -e "\n" | cat milestone-notes.md superfields/release-notes.md > superfields/release-notes.md.new
           mv superfields/release-notes.md.new superfields/release-notes.md
       - name: Remove milestone notes
         run: rm milestone-notes.md

--- a/.github/workflows/setversion.yml
+++ b/.github/workflows/setversion.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Create milestone notes
         uses: UnforgivenPL/milestone-notes@v1
         with:
-          match-milestone: ^${{ steps.what-version.outputs.version }}
+          match-milestone: "^${{ steps.what-version.outputs.version }} "
           repository: ${{ github.repository }}
           labels: "enhancement, api, bug"
       - name: Format milestone notes

--- a/.github/workflows/setversion.yml
+++ b/.github/workflows/setversion.yml
@@ -29,7 +29,7 @@ jobs:
           settings-path: ${{ github.workspace }} # location for the settings.xml file
       - name: Set version and update readme
         run: |
-          export VERSION="$ {{ needs.prepare.outputs.version }}"
+          export VERSION="${{ needs.prepare.outputs.version }}"
           mvn versions:set -DnewVersion=$VERSION --file pom.xml
           mvn versions:set -DnewVersion=$VERSION --file superfields/pom.xml
           sed -i -e s/{VERSION}/$VERSION/g ./README.md

--- a/superfields/release-notes.md
+++ b/superfields/release-notes.md
@@ -1,0 +1,65 @@
+# 0.6 - ComponentObserver and UnloadObserver
+## New features and enhancements
+* \#66 - [A field that changes value on becoming shown and hidden](https://api.github.com/repos/vaadin-miki/super-fields/issues/66)
+* \#69 - [ComponentObserver - reusing client-side IntersectionObserver as a server-side component](https://api.github.com/repos/vaadin-miki/super-fields/issues/69)
+* \#75 - [Component for encapsulating beforeunload events](https://api.github.com/repos/vaadin-miki/super-fields/issues/75)
+* \#80 - [Expand SuperTabs to work also with removing tab contents](https://api.github.com/repos/vaadin-miki/super-fields/issues/80)
+* \#82 - [Allow overriding default container in SuperTabs](https://api.github.com/repos/vaadin-miki/super-fields/issues/82)
+## Changes to API
+* \#76 - [Make Vaadin dependencies not transitive](https://api.github.com/repos/vaadin-miki/super-fields/issues/76)
+* \#85 - [Add WithItems also to ItemGrid](https://api.github.com/repos/vaadin-miki/super-fields/issues/85)
+* \#86 - [Create WithValue to allow chaining setValue calls](https://api.github.com/repos/vaadin-miki/super-fields/issues/86)
+* \#89 - [Expose DatePicker and TimePicker in SuperDateTimePicker](https://api.github.com/repos/vaadin-miki/super-fields/issues/89)
+* \#92 - [Add WithIdMixin to all components](https://api.github.com/repos/vaadin-miki/super-fields/issues/92)
+## Bug fixes
+* \#81 - [Setting date display pattern does not work out-of-the-box](https://api.github.com/repos/vaadin-miki/super-fields/issues/81)
+* \#83 - [SuperTabs should implement HasItems](https://api.github.com/repos/vaadin-miki/super-fields/issues/83)
+* \#90 - [SuperTabs should be using removing handler by default](https://api.github.com/repos/vaadin-miki/super-fields/issues/90)
+* \#93 - ["this.observer is undefined" after ObservedField is removed from dom and added again](https://api.github.com/repos/vaadin-miki/super-fields/issues/93)
+* \#98 - [Vaadin production mode not included](https://api.github.com/repos/vaadin-miki/super-fields/issues/98)
+# 0.5.1 - Fix maven dependencies
+## New features and enhancements
+(nothing reported)
+## Changes to API
+(nothing reported)
+## Bug fixes
+* \#70 - [Parent pom unavailable for Directory downloads](https://api.github.com/repos/vaadin-miki/super-fields/issues/70)
+# 0.5 - LazyLoad
+## New features and enhancements
+* \#50 - [Investigate lazy loading for ItemGrid](https://api.github.com/repos/vaadin-miki/super-fields/issues/50)
+* \#51 - [Custom date formatting for date components](https://api.github.com/repos/vaadin-miki/super-fields/issues/51)
+## Changes to API
+(nothing reported)
+## Bug fixes
+* \#56 - [Set width to full in number fields](https://api.github.com/repos/vaadin-miki/super-fields/issues/56)
+# 0.4 - ItemGrid
+## New features and enhancements
+* \#34 - [Basic version of `ItemGrid`](https://api.github.com/repos/vaadin-miki/super-fields/issues/34)
+## Changes to API
+(nothing reported)
+## Bug fixes
+(nothing reported)
+# 0.3 - SuperTabs
+## New features and enhancements
+* \#26 - [SuperTabs](https://api.github.com/repos/vaadin-miki/super-fields/issues/26)
+## Changes to API
+* \#30 - [Add .withXYZ methods to all fields](https://api.github.com/repos/vaadin-miki/super-fields/issues/30)
+## Bug fixes
+(nothing reported)
+# 0.2 - Date components
+## New features and enhancements
+* \#12 - [SuperDatePicker](https://api.github.com/repos/vaadin-miki/super-fields/issues/12)
+* \#20 - [SuperDateTimePicker](https://api.github.com/repos/vaadin-miki/super-fields/issues/20)
+## Changes to API
+(nothing reported)
+## Bug fixes
+(nothing reported)
+# 0.1 - Number fields
+## New features and enhancements
+* \#2 - [SuperDoubleField](https://api.github.com/repos/vaadin-miki/super-fields/issues/2)
+* \#4 - [SuperIntegerField and SuperLongField](https://api.github.com/repos/vaadin-miki/super-fields/issues/4)
+* \#5 - [SuperBigDecimalField](https://api.github.com/repos/vaadin-miki/super-fields/issues/5)
+## Changes to API
+(nothing reported)
+## Bug fixes
+* \#10 - [Max integer length does not work if it is a multiplication of grouping size](https://api.github.com/repos/vaadin-miki/super-fields/issues/10)


### PR DESCRIPTION
closes #107 

workflows were updated to fetch closed tickets from a milestone that matches release branch name (so for branch `release-0.6.1` milestone starting with `0.6.1 ` will be matched