### PR TITLE
117 auto release

### DIFF
--- a/.github/workflows/makerelease.yml
+++ b/.github/workflows/makerelease.yml
@@ -1,0 +1,24 @@
+name: Make Release
+
+on:
+  push:
+    branches: [117-*]
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v2
+      - id: variables
+        run: |
+          set -x
+          echo "::set-output name=version::`head -1 superfields/release-notes.md | cut -d' ' -f2`"
+          echo "::set-output name=title::`head -1 superfields/release-notes.md | sed -n -e 's/^.* - //p'`"
+          echo "::set-output name=notes::`cat superfields/release-notes.md | sed -e '0,/^# /d;/^# /,$d'`"
+      - id: test
+        run: |
+          echo "${{ steps.variables.outputs.version }}"
+          echo "${{ steps.variables.outputs.title }}"
+          echo "${{ steps.variables.outputs.notes }}"

--- a/.github/workflows/makerelease.yml
+++ b/.github/workflows/makerelease.yml
@@ -19,7 +19,7 @@ jobs:
           export NOTES=`cat superfields/release-notes.md | sed -e '0,/^# /d;/^# /,$d'`
           export NOTES="${NOTES//'%'/'%25'}"
           export NOTES="${NOTES//$'\n'/'%0A'}"
-          export NOTES="${NOTES//$'\r'/'%0D'}""
+          export NOTES="${NOTES//$'\r'/'%0D'}"
           echo "::set-output name=notes::$NOTES"
       - id: test
         run: |

--- a/.github/workflows/makerelease.yml
+++ b/.github/workflows/makerelease.yml
@@ -2,7 +2,7 @@ name: Make Release
 
 on:
   push:
-    branches: [117-*]
+    branches: [master]
 
 jobs:
   create-release:
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/checkout@v2
       - id: variables
         run: |
-          set -x
           echo "::set-output name=version::`head -1 superfields/release-notes.md | cut -d' ' -f2`"
           echo "::set-output name=title::`head -1 superfields/release-notes.md | sed -n -e 's/^.* - //p'`"
           export NOTES=`cat superfields/release-notes.md | sed -e '0,/^# /d;/^# /,$d'`
@@ -21,8 +20,15 @@ jobs:
           export NOTES="${NOTES//$'\n'/'%0A'}"
           export NOTES="${NOTES//$'\r'/'%0D'}"
           echo "::set-output name=notes::$NOTES"
-      - id: test
-        run: |
-          echo "${{ steps.variables.outputs.version }}"
-          echo "${{ steps.variables.outputs.title }}"
-          echo "${{ steps.variables.outputs.notes }}"
+      - name: Create Release
+        uses: fleskesvor/create-release@feature/support-target-commitish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: "v${{ steps.variables.outputs.version }}.test"
+          commitish: "master"
+          release_name: "${{ steps.variables.outputs.version }} - ${{ steps.variables.outputs.title }}"
+          body: |
+            ${{ steps.variables.outputs.notes }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/makerelease.yml
+++ b/.github/workflows/makerelease.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: "v${{ steps.variables.outputs.version }}.test"
+          tag_name: "v${{ steps.variables.outputs.version }}"
           commitish: "master"
           release_name: "${{ steps.variables.outputs.version }} - ${{ steps.variables.outputs.title }}"
           body: |

--- a/.github/workflows/makerelease.yml
+++ b/.github/workflows/makerelease.yml
@@ -16,7 +16,11 @@ jobs:
           set -x
           echo "::set-output name=version::`head -1 superfields/release-notes.md | cut -d' ' -f2`"
           echo "::set-output name=title::`head -1 superfields/release-notes.md | sed -n -e 's/^.* - //p'`"
-          echo "::set-output name=notes::`cat superfields/release-notes.md | sed -e '0,/^# /d;/^# /,$d'`"
+          export NOTES=`cat superfields/release-notes.md | sed -e '0,/^# /d;/^# /,$d'`
+          export NOTES="${NOTES//'%'/'%25'}"
+          export NOTES="${NOTES//$'\n'/'%0A'}"
+          export NOTES="${NOTES//$'\r'/'%0D'}""
+          echo "::set-output name=notes::$NOTES"
       - id: test
         run: |
           echo "${{ steps.variables.outputs.version }}"


### PR DESCRIPTION
closes #117 

when a new push to `master` is done, the workflow should fetch the latest version from `superfields/release-notes.md` and then determine the following:
* number of the latest version
* title of the release
* contents of the release
