### PR TITLE
#132 done

### DIFF
--- a/.github/workflows/makerelease.yml
+++ b/.github/workflows/makerelease.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create Release
         uses: fleskesvor/create-release@feature/support-target-commitish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}
         with:
           tag_name: "v${{ steps.variables.outputs.version }}"
           commitish: "master"


### PR DESCRIPTION
closes #132 

now creating a release uses personal access token rather than the default one