### PR TITLE
#137 done

### DIFF
--- a/demo-v14/src/main/java/org/vaadin/miki/MainView.java
+++ b/demo-v14/src/main/java/org/vaadin/miki/MainView.java
@@ -19,6 +19,8 @@ import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.component.tabs.Tab;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
+import com.vaadin.flow.function.SerializableBiConsumer;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import org.vaadin.miki.markers.HasLocale;
@@ -51,7 +53,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -68,9 +69,9 @@ public class MainView extends VerticalLayout {
 
     private final Map<Class<?>, Component> components = new LinkedHashMap<>();
 
-    private final Map<Class<?>, Consumer<Object>> afterLocaleChange = new HashMap<>();
+    private final Map<Class<?>, SerializableConsumer<Object>> afterLocaleChange = new HashMap<>();
 
-    private final Map<Class<?>, BiConsumer<Component, Consumer<Component[]>>> contentBuilders = new LinkedHashMap<>();
+    private final Map<Class<?>, SerializableBiConsumer<Component, Consumer<Component[]>>> contentBuilders = new LinkedHashMap<>();
 
     private static Component generateParagraph(Class<? extends Component> type, int row, int column) {
         Paragraph result = new Paragraph(type.getSimpleName());
@@ -289,7 +290,7 @@ public class MainView extends VerticalLayout {
         );
         this.components.put(ObservedField.class, new ObservedField());
         this.components.put(ComponentObserver.class, new ComponentObserver());
-        this.components.put(UnloadObserver.class, new UnloadObserver(false));
+        this.components.put(UnloadObserver.class, UnloadObserver.get(false));
         this.components.put(ItemGrid.class, new ItemGrid<Class<? extends Component>>(
                 null,
                 () -> {

--- a/superfields/src/main/java/org/vaadin/miki/superfields/unload/UnloadObserver.java
+++ b/superfields/src/main/java/org/vaadin/miki/superfields/unload/UnloadObserver.java
@@ -13,13 +13,38 @@ import org.vaadin.miki.markers.WithIdMixin;
 /**
  * Server-side component that listens to {@code beforeunload} events.
  * Based on <a href="https://vaadin.com/forum/thread/17523194/unsaved-changes-detect-page-exit-or-reload">the code by Kaspar Scherrer and Stuart Robinson</a>.
+ * Warning: this class is a Singleton; the class is final, the constructors are private and there is at most one global instance.
  *
  * @author Kaspar Scherrer, Stuart Robinson; adapted to web-component by miki
  * @since 2020-04-29
  */
 @JsModule("./unload-observer.js")
 @Tag("unload-observer")
-public class UnloadObserver extends PolymerTemplate<TemplateModel> implements WithIdMixin<UnloadObserver> {
+public final class UnloadObserver extends PolymerTemplate<TemplateModel> implements WithIdMixin<UnloadObserver> {
+
+    private static UnloadObserver instance = null;
+
+    /**
+     * Returns the current instance. Will create one using default no-arg constructor if none is present yet.
+     * @return An instance of {@link UnloadObserver}.
+     */
+    public static UnloadObserver get() {
+        if(instance == null)
+            instance = new UnloadObserver();
+        return instance;
+    }
+
+    /**
+     * Returns the current instance. Will create one if needed and set its {@link #setQueryingOnUnload(boolean)}.
+     * @param queryingOnUnload Whether or not query at page close.
+     * @return An instance of {@link UnloadObserver}.
+     */
+    public static UnloadObserver get(boolean queryingOnUnload) {
+        if(instance == null)
+            instance = new UnloadObserver(queryingOnUnload);
+        else instance.setQueryingOnUnload(queryingOnUnload);
+        return instance;
+    }
 
     private boolean queryingOnUnload;
 
@@ -28,7 +53,7 @@ public class UnloadObserver extends PolymerTemplate<TemplateModel> implements Wi
     /**
      * Creates the unload observer and by default queries the user on unloading the page.
      */
-    public UnloadObserver() {
+    private UnloadObserver() {
         this(true);
     }
 
@@ -36,7 +61,7 @@ public class UnloadObserver extends PolymerTemplate<TemplateModel> implements Wi
      * Creates the unload observer.
      * @param queryOnUnload Whether or not to query the user on unloading the page.
      */
-    public UnloadObserver(boolean queryOnUnload) {
+    private UnloadObserver(boolean queryOnUnload) {
         super();
         this.setQueryingOnUnload(queryOnUnload);
     }
@@ -102,10 +127,7 @@ public class UnloadObserver extends PolymerTemplate<TemplateModel> implements Wi
 
     @Override
     protected void onDetach(DetachEvent detachEvent) {
-        if(this.clientInitialised) {
-            this.getElement().callJsFunction("stopObserver");
-            this.clientInitialised = false;
-        }
+        this.clientInitialised = false;
         super.onDetach(detachEvent);
     }
 


### PR DESCRIPTION
UnloadObserver is now a singleton in Java; also client-side code is now globally stored in `window.Vaadin.unloadObserver`

closes #137 