### PR TITLE
#178 UnloadObserver is now UI-scoped singleton

### DIFF
--- a/demo-v14/src/main/java/org/vaadin/miki/MainView.java
+++ b/demo-v14/src/main/java/org/vaadin/miki/MainView.java
@@ -341,7 +341,7 @@ public class MainView extends VerticalLayout {
         );
         this.components.put(ObservedField.class, new ObservedField());
         this.components.put(ComponentObserver.class, new ComponentObserver());
-        this.components.put(UnloadObserver.class, UnloadObserver.get(false));
+        this.components.put(UnloadObserver.class, UnloadObserver.get().withoutQueryingOnUnload());
         this.components.put(ItemGrid.class, new ItemGrid<Class<? extends Component>>(
                 null,
                 () -> {

--- a/superfields/src/main/java/org/vaadin/miki/superfields/unload/UnloadObserver.java
+++ b/superfields/src/main/java/org/vaadin/miki/superfields/unload/UnloadObserver.java
@@ -2,8 +2,10 @@ package org.vaadin.miki.superfields.unload;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
 import com.vaadin.flow.shared.Registration;
@@ -18,47 +20,41 @@ import org.vaadin.miki.markers.WithIdMixin;
  * If {@link #isQueryingOnUnload()} is {@code false}, the event on the server will be called just before the page is unloaded.
  * Note that the component must be present in the DOM structure in the browser for the event to be received on the server.
  *
- * Warning: this class is a {@link ThreadLocal} singleton; the class is final, the constructors are private and there is at most one global instance per thread.
+ * Warning: this class is pretty much a {@link UI}-scoped singleton; the class is final, the constructors are private and there is at most one global instance per UI.
  *
- * Warning: when the page is unloaded, the thread-local instance should be removed to prevent memory leaks. See {@link #remove()}.
- *
- * @author Kaspar Scherrer, Stuart Robinson; adapted to web-component by miki
+ * @author Kaspar Scherrer, Stuart Robinson; adapted to web-component by miki; bugfixing and enhancements by Jean-François Lamy
  * @since 2020-04-29
  */
 @JsModule("./unload-observer.js")
 @Tag("unload-observer")
 public final class UnloadObserver extends PolymerTemplate<TemplateModel> implements WithIdMixin<UnloadObserver> {
 
-    private static final ThreadLocal<UnloadObserver> INSTANCES = new ThreadLocal<>();
-
     /**
-     * Returns the current instance. Will create one using default no-arg constructor if none is present yet.
+     * Returns or creates an instance for current UI.
+     * The result is associated with the UI, but not added to any of its components.
      * @return An instance of {@link UnloadObserver}.
+     * @throws IllegalStateException if there is no current {@link UI}.
      */
     public static UnloadObserver get() {
-        if(INSTANCES.get() == null)
-            INSTANCES.set(new UnloadObserver());
-        return INSTANCES.get();
+        UI ui = UI.getCurrent();
+        if(ui == null)
+            throw new IllegalStateException("there is no UI available to create UnloadObserver for");
+        return get(ui);
     }
 
     /**
-     * Returns the current instance. Will create one if needed and set its {@link #setQueryingOnUnload(boolean)}.
-     * @param queryingOnUnload Whether or not query at page close.
+     * Returns or creates an instance for a given UI.
+     * The result is associated with the UI, but not added to any of its components.
+     * @param ui A {@link UI} to register the instance of {@link UnloadObserver} in. Must not be {@code null}.
      * @return An instance of {@link UnloadObserver}.
      */
-    public static UnloadObserver get(boolean queryingOnUnload) {
-        if(INSTANCES.get() == null)
-            INSTANCES.set(new UnloadObserver(queryingOnUnload));
-        else INSTANCES.get().setQueryingOnUnload(queryingOnUnload);
-        return INSTANCES.get();
-    }
-
-    /**
-     * Cleans up the thread-local variable. This method is called automatically when the component receives {@code unload} event.
-     */
-    public static void remove() {
-        if(INSTANCES.get() != null)
-            INSTANCES.remove();
+    public static UnloadObserver get(UI ui) {
+        UnloadObserver instance = ComponentUtil.getData(ui, UnloadObserver.class);
+        if(instance == null) {
+            instance = new UnloadObserver();
+            ComponentUtil.setData(ui, UnloadObserver.class, instance);
+        }
+        return instance;
     }
 
     private boolean queryingOnUnload;


### PR DESCRIPTION
using ComponentUtil.getData/setData to keep the instance associated with a given UI

creating UnloadObserver does not add it anywhere, that still needs to be done manually

also updated demo app to reflect changes

closes #178 