### PR TITLE
182 183 unload observer fixes

### DIFF
--- a/superfields/README.md
+++ b/superfields/README.md
@@ -94,6 +94,6 @@ A boolean field that changes its value (`true` or `false`) depending on whether 
 
 A component that listens and reacts to browser's `beforeunload` events that happen for example when browser window/tab is closed. The support [varies between browsers](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event), but in general is quite good. This should work with at least the major browsers.
 
-**Please note**: This component is a singleton - there can be only one instance of it. As such, please refrain from adding the same instance into multiple layouts.
+**Please note**: This component is basically a UI-scoped singleton - there can be only one instance of it per active UI. As such, please refrain from adding the same instance into multiple layouts.
 
-The code is based on solution [posted by Kaspar Scherrer and Stuart Robinson](https://vaadin.com/forum/thread/17523194/unsaved-changes-detect-page-exit-or-reload). It does not work with `<a href>` or `Anchor` as download links, so please use [FileDownloadWrapper](https://vaadin.com/directory/component/file-download-wrapper/discussions) for that. 
+The code is based on solution [posted by Kaspar Scherrer and Stuart Robinson](https://vaadin.com/forum/thread/17523194/unsaved-changes-detect-page-exit-or-reload) (with invaluable feedback from Jean-François Lamy). It does not work with `<a href>` or `Anchor` as download links, so please use [FileDownloadWrapper](https://vaadin.com/directory/component/file-download-wrapper/discussions) for that.

--- a/superfields/src/test/java/org/vaadin/miki/superfields/unload/SampleView.java
+++ b/superfields/src/test/java/org/vaadin/miki/superfields/unload/SampleView.java
@@ -1,0 +1,13 @@
+package org.vaadin.miki.superfields.unload;
+
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+/**
+ * A dummy view for testing.
+ * @author miki
+ * @since 2020-07-03
+ */
+@Route("")
+public class SampleView extends VerticalLayout {
+}

--- a/superfields/src/test/java/org/vaadin/miki/superfields/unload/UnloadObserverTest.java
+++ b/superfields/src/test/java/org/vaadin/miki/superfields/unload/UnloadObserverTest.java
@@ -1,0 +1,80 @@
+package org.vaadin.miki.superfields.unload;
+
+import com.github.mvysny.kaributesting.v10.MockVaadin;
+import com.github.mvysny.kaributesting.v10.Routes;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+public class UnloadObserverTest {
+
+    @Before
+    public void setUp() {
+        final Routes routes = new Routes();
+        routes.autoDiscoverViews();
+        MockVaadin.setup(routes);
+    }
+
+    @After
+    public void tearDown() {
+        MockVaadin.tearDown();
+    }
+
+    @Test
+    public void testCreatingUnattached() {
+        Assert.assertNotNull("there should be a UI for current thread", UI.getCurrent());
+        UnloadObserver instance = UnloadObserver.get();
+        Assert.assertNotNull("there should be a non-null instance of unload observer", instance);
+        UnloadObserver second = UnloadObserver.get();
+        Assert.assertNotNull("calling get() second time should give a non-null result", second);
+        Assert.assertSame("both instances should be the same", instance, second);
+        Assert.assertFalse("unload observer should not be attached to anything", instance.getParent().isPresent());
+        Assert.assertFalse("unload observer should not be part of any UI", instance.getUI().isPresent());
+    }
+
+    private void assertValidUnloadObserver(UnloadObserver instance, UI ui, Component parent) {
+        Assert.assertTrue("unload observer should be attached to something", instance.getParent().isPresent());
+        Assert.assertSame("unload observer should be attached to given parent", instance.getParent().get(), parent);
+        Assert.assertTrue("unload observer should be part of some UI", instance.getUI().isPresent());
+        Assert.assertSame("unload observer should be part of given UI", instance.getUI().get(), ui);
+
+        UnloadObserver second = UnloadObserver.getAttached();
+        Assert.assertSame("getting attached should return the same object", instance, second);
+    }
+
+    @Test
+    public void testCreatingAttachedToUI() {
+        Assert.assertNotNull("there should be a UI for current thread", UI.getCurrent());
+        UnloadObserver instance = UnloadObserver.getAttached();
+        Assert.assertNotNull("there should be a non-null instance of unload observer", instance);
+        UnloadObserver second = UnloadObserver.get();
+        Assert.assertNotNull("calling get() second time should give a non-null result", second);
+        Assert.assertSame("both instances should be the same", instance, second);
+        this.assertValidUnloadObserver(instance, UI.getCurrent(), UI.getCurrent());
+    }
+
+    @Test
+    public void testCreatingAttachedToAComponent() {
+        UI.getCurrent().navigate(""); // go to sample view
+        Optional<SampleView> perhapsView = UI.getCurrent().getChildren().filter(SampleView.class::isInstance).map(SampleView.class::cast).findFirst();
+        Assert.assertTrue("a view should have been found", perhapsView.isPresent());
+        SampleView view = perhapsView.get();
+        UnloadObserver instance = UnloadObserver.getAttached(view);
+        this.assertValidUnloadObserver(instance, UI.getCurrent(), view);
+
+        UnloadObserver second = UnloadObserver.get();
+        Assert.assertSame("call to get() should result in already attached observer", instance, second);
+
+        // now attaching from view to UI
+        second = UnloadObserver.getAttached();
+        Assert.assertSame("call to getAttached() should return previous instance, but with changed properties", instance, second);
+        this.assertValidUnloadObserver(instance, UI.getCurrent(), UI.getCurrent());
+        Assert.assertTrue("view should no longer contain the unload observer", view.getChildren().noneMatch(component -> component == instance));
+    }
+
+}


### PR DESCRIPTION
`UnloadObserver` now has two static methods for creating/reusing an instance attached to a given component/current UI, named `getAttached`.

closes #182 
closes #183 