### PR TITLE
Removing beforeunload EventListener on detach

### DIFF
--- a/superfields/src/main/java/org/vaadin/miki/superfields/unload/UnloadObserver.java
+++ b/superfields/src/main/java/org/vaadin/miki/superfields/unload/UnloadObserver.java
@@ -186,6 +186,12 @@ public final class UnloadObserver extends PolymerTemplate<TemplateModel> impleme
     @Override
     protected void onDetach(DetachEvent detachEvent) {
         this.clientInitialised = false;
+        
+        // getElement().callJsFunction(..) doesn't work in this phase, so let's execute the necessary js directly without the element involved.
+        detachEvent.getUI().getPage().executeJs(
+                "if (window.Vaadin.unloadObserver.attemptHandler !== undefined) {" +
+                "    window.removeEventListener('beforeunload', window.Vaadin.unloadObserver.attemptHandler);" +
+                "}");
         super.onDetach(detachEvent);
     }
 


### PR DESCRIPTION
This enables a View setup where the UnloadObserver is added to a child view "A". Once the user navigates to another child view "B" of the same MainView, the UnloadObserver must be gone. I could do this manually in child view "A" (and all other views with that behaviour) or the UnloadObserver could take care of this directly so I don't have to remember to add a detach listener to all my views that use an unloadObserver. I believe this does not break the component for those that attach the UnloadObserver to the UI directly.