### PR TITLE
super date (time) picker now optionally always accepts short year

### DIFF
--- a/demo-v14/src/main/java/org/vaadin/miki/DemoComponentFactory.java
+++ b/demo-v14/src/main/java/org/vaadin/miki/DemoComponentFactory.java
@@ -303,7 +303,7 @@ public final class DemoComponentFactory implements Serializable {
     private void buildHasDatePattern(Component component, Consumer<Component[]> callback) {
         final ComboBox<DatePattern> patterns = new ComboBox<>("Select date display pattern:",
                 DatePatterns.YYYY_MM_DD, DatePatterns.M_D_YYYY_SLASH,
-                DatePatterns.DD_MM_YYYY_DOTTED, DatePatterns.D_M_YY_DOTTED,
+                DatePatterns.DD_MM_YYYY_DOTTED, DatePatterns.DD_MM_YY_OR_YYYY_DOTTED, DatePatterns.D_M_YY_DOTTED,
                 DatePatterns.YYYYMMDD, DatePatterns.DDMMYY
         );
         final Button clearPattern = new Button("Clear pattern", event -> ((HasDatePattern)component).setDatePattern(null));

--- a/superfields/src/main/java/org/vaadin/miki/shared/dates/DatePattern.java
+++ b/superfields/src/main/java/org/vaadin/miki/shared/dates/DatePattern.java
@@ -48,6 +48,8 @@ public class DatePattern implements Serializable {
 
     private boolean previousCenturyBelowBoundary = false;
 
+    private boolean shortYearAlwaysAccepted = false;
+
     private Order displayOrder = Order.YEAR_MONTH_DAY;
 
     /**
@@ -317,6 +319,37 @@ public class DatePattern implements Serializable {
     }
 
     /**
+     * Allows short year to be always accepted as input.
+     * @param shortYearAlwaysAccepted When {@code true}, short year can always be entered and will be parsed properly and displayed as full year.
+     * @see #setBaseCentury(int)
+     * @see #setCenturyBoundaryYear(int)
+     * @see #setPreviousCenturyBelowBoundary(boolean)
+     * @see #setShortYear(boolean)
+     */
+    public void setShortYearAlwaysAccepted(boolean shortYearAlwaysAccepted) {
+        this.shortYearAlwaysAccepted = shortYearAlwaysAccepted;
+    }
+
+    /**
+     * Whether or not short year is accepted as user input even if {@link #isShortYear()} returns {@code false}.
+     * @return When {@code true}, user can input last two digits of the year and it will be properly parsed.
+     */
+    public boolean isShortYearAlwaysAccepted() {
+        return shortYearAlwaysAccepted;
+    }
+
+    /**
+     * Chains {@link #setShortYearAlwaysAccepted(boolean)} and returns itself.
+     * @param shortYearAlwaysAccepted Whether or not to always accept short year as user input.
+     * @return This.
+     * @see #setShortYearAlwaysAccepted(boolean)
+     */
+    public DatePattern withShortYearAlwaysAccepted(boolean shortYearAlwaysAccepted) {
+        this.setShortYearAlwaysAccepted(shortYearAlwaysAccepted);
+        return this;
+    }
+
+    /**
      * Returns display name defined in the constructor. The display name is irrelevant in {@link #equals(Object)} and {@link #hashCode()}.
      * @return Display name. May be {@code null} when no-arg constructor has been used.
      */
@@ -336,12 +369,13 @@ public class DatePattern implements Serializable {
                 getBaseCentury() == pattern.getBaseCentury() &&
                 getCenturyBoundaryYear() == pattern.getCenturyBoundaryYear() &&
                 isPreviousCenturyBelowBoundary() == pattern.isPreviousCenturyBelowBoundary() &&
+                isShortYearAlwaysAccepted() == pattern.isShortYearAlwaysAccepted() &&
                 getDisplayOrder() == pattern.getDisplayOrder();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getSeparator(), isZeroPrefixedDay(), isZeroPrefixedMonth(), isShortYear(), getBaseCentury(), getCenturyBoundaryYear(), isPreviousCenturyBelowBoundary(), getDisplayOrder());
+        return Objects.hash(getSeparator(), isZeroPrefixedDay(), isZeroPrefixedMonth(), isShortYear(), getBaseCentury(), getCenturyBoundaryYear(), isPreviousCenturyBelowBoundary(), isShortYearAlwaysAccepted(), getDisplayOrder());
     }
 
     @Override
@@ -355,6 +389,7 @@ public class DatePattern implements Serializable {
                 ", baseCentury=" + baseCentury +
                 ", centuryBoundaryYear=" + centuryBoundaryYear +
                 ", previousCenturyBelowBoundary=" + previousCenturyBelowBoundary +
+                ", shortYearAlwaysAccepted=" + shortYearAlwaysAccepted +
                 ", displayOrder=" + displayOrder +
                 '}' :
                 getDisplayName();

--- a/superfields/src/main/java/org/vaadin/miki/shared/dates/DatePatterns.java
+++ b/superfields/src/main/java/org/vaadin/miki/shared/dates/DatePatterns.java
@@ -20,6 +20,16 @@ public final class DatePatterns {
             .withSeparator('.');
 
     /**
+     * Uses zero-prefixed day and month, optionally full year, separated by {@code .}.
+     * For short years the century boundary year is 40 (years less than 40 are from 21st century).
+     */
+    public static final DatePattern DD_MM_YY_OR_YYYY_DOTTED = new DatePattern("dd.MM.(yy)yy")
+            .withDisplayOrder(DatePattern.Order.DAY_MONTH_YEAR)
+            .withShortYearAlwaysAccepted(true)
+            .withBaseCentury(21).withCenturyBoundaryYear(40).withPreviousCenturyBelowBoundary(false)
+            .withSeparator('.');
+
+    /**
      * Uses day, month and short year with century boundary year 40 (years less than 40 are from 21st century), separated by {@code .}.
      */
     public static final DatePattern D_M_YY_DOTTED = new DatePattern("d.M.yy")

--- a/superfields/src/main/java/org/vaadin/miki/superfields/dates/DatePatternDelegate.java
+++ b/superfields/src/main/java/org/vaadin/miki/superfields/dates/DatePatternDelegate.java
@@ -51,7 +51,7 @@ final class DatePatternDelegate<C extends Component & HasDatePattern> implements
                     builder.append(yearPart).append(monthPart).append(dayPart);
                     break;
             }
-            if (pattern.isShortYear()) {
+            if (pattern.isShortYear() || pattern.isShortYearAlwaysAccepted()) {
                 builder.append(pattern.isPreviousCenturyBelowBoundary() ? '+' : '-');
                 builder.append(String.format("%02d", pattern.getBaseCentury() % 100));
                 builder.append(String.format("%02d", pattern.getCenturyBoundaryYear() % 100));

--- a/superfields/src/main/resources/META-INF/resources/frontend/date-pattern-mixin.js
+++ b/superfields/src/main/resources/META-INF/resources/frontend/date-pattern-mixin.js
@@ -149,16 +149,18 @@ export class DatePatternMixin {
                        }
                     }
                     // end of parsing stuff
-
-                    // now, if short year is used
-                    if (shortYear) {
+                    console.log("SDP: parsed so far year, month, date "+year+", "+month+", "+date);
+                    // now, if short year is allowed (i.e. there is a description of default century and boundary year)
+                    if (ddp.length === 12 || ddp.length === 11) {
+                    // if (shortYear) {
                         const boundaryYear = parseInt(ddp.substr(-2));
                         const defaultCentury = parseInt(ddp.substr(-4, 2));
                         if (year < boundaryYear) {
                             year += (ddp[ddp.length-5] === '+' ? defaultCentury - 2 : defaultCentury - 1) * 100;
                         } else if (year < 100) {
-                            year += (ddp[ddp.length-5] === '+' ? defaultCentury - 2 : defaultCentury - 1) * 100;
+                            year += (ddp[ddp.length-5] === '+' ? defaultCentury - 1 : defaultCentury - 2) * 100;
                         }
+                        console.log("SDP: after fixing the year is "+year);
                     }
                     // return result
                     if (date !== undefined) {

--- a/superfields/src/main/resources/META-INF/resources/frontend/date-pattern-mixin.js
+++ b/superfields/src/main/resources/META-INF/resources/frontend/date-pattern-mixin.js
@@ -149,10 +149,8 @@ export class DatePatternMixin {
                        }
                     }
                     // end of parsing stuff
-                    console.log("SDP: parsed so far year, month, date "+year+", "+month+", "+date);
                     // now, if short year is allowed (i.e. there is a description of default century and boundary year)
                     if (ddp.length === 12 || ddp.length === 11) {
-                    // if (shortYear) {
                         const boundaryYear = parseInt(ddp.substr(-2));
                         const defaultCentury = parseInt(ddp.substr(-4, 2));
                         if (year < boundaryYear) {


### PR DESCRIPTION
closes #212 
closes #216 

check for invoking extra filling of the short year is done now based on length of the pattern rather than presence of the short year indicator