### PR TITLE
220 release process

### DIFF
--- a/.github/workflows/releasenotes.yml
+++ b/.github/workflows/releasenotes.yml
@@ -54,7 +54,7 @@ jobs:
           target: development
           repository: ${{ github.repository }}
           token: ${{ secrets.ACTIONS_PAT }}
-          pr-title: Release notes for version ${{ steps.what-version.outputs.version }}
-          pr-body: Automatically updated notes ${{ steps.what-version.outputs.version }}.
+          pr-title: Release notes for version ${{ steps.version.outputs.version }}
+          pr-body: Automatically updated notes ${{ steps.version.outputs.version }}.
           pr-assignees: ${{ github.actor }}
           pr-labels: release

--- a/.github/workflows/setversion.yml
+++ b/.github/workflows/setversion.yml
@@ -27,8 +27,8 @@ jobs:
         run: |
           set -x
           export VERSION="${{ steps.what-version.outputs.version }}"
+          mvn versions:set -DnewVersion=$VERSION --file pom.xml -DartifactId=superfields
           mvn versions:set -DnewVersion=$VERSION --file pom.xml
-          mvn versions:set -DnewVersion=$VERSION --file superfields/pom.xml
           sed -i -e s/{VERSION}/$VERSION/g ./README.md
       - name: Push changes
         uses: stefanzweifel/git-auto-commit-action@v4.1.6


### PR DESCRIPTION
closes #220 

setting version now also updates the dependency in the demo (which was why the process failed in the first place)