### PR TITLE
#329 fixed

### DIFF
--- a/demo-v14/src/main/java/org/vaadin/miki/demo/builders/FocusNotifierBuilder.java
+++ b/demo-v14/src/main/java/org/vaadin/miki/demo/builders/FocusNotifierBuilder.java
@@ -2,6 +2,8 @@ package org.vaadin.miki.demo.builders;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.FocusNotifier;
+import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.notification.Notification;
 import org.vaadin.miki.demo.ContentBuilder;
@@ -22,6 +24,10 @@ public class FocusNotifierBuilder implements ContentBuilder<FocusNotifier<?>> {
         component.addFocusListener(event ->
                 Notification.show(String.format(NotificationConstants.FOCUS_MESSAGE, component.getClass().getSimpleName()), NotificationConstants.NOTIFICATION_TIME, Notification.Position.BOTTOM_END)
         );
-        callback.accept(new Component[]{new Span("Focus the demo component to see a notification.")});
+        if(component instanceof Focusable) {
+            final Button focus = new Button("Focus component", event -> ((Focusable<?>) component).focus());
+            callback.accept(new Component[]{focus, new Span("(not all components can be focused, despite being Focusable)")});
+        }
+        callback.accept(new Component[]{new Span("Focus the demoed component to see a notification.")});
     }
 }

--- a/superfields/src/main/java/org/vaadin/miki/superfields/numbers/AbstractSuperNumberField.java
+++ b/superfields/src/main/java/org/vaadin/miki/superfields/numbers/AbstractSuperNumberField.java
@@ -747,6 +747,16 @@ public abstract class AbstractSuperNumberField<T extends Number, SELF extends Ab
         return this.field.isHelperAbove();
     }
 
+    @Override
+    public void focus() {
+        this.field.focus();
+    }
+
+    @Override
+    public void blur() {
+        this.field.blur();
+    }
+
     /**
      * Explicitly invokes code that would otherwise be called when the component receives focus.
      * For testing purposes only.


### PR DESCRIPTION
`.focus()` and `.blur()` are now forwarded to the underlying text field (in number fields)