### PR TITLE
refactor: upgrade to Vaadin 25

### DIFF
--- a/demo-v24/frontend/generated/vaadin-featureflags.js
+++ b/demo-v24/frontend/generated/vaadin-featureflags.js
@@ -2,15 +2,13 @@
 window.Vaadin = window.Vaadin || {};
 window.Vaadin.featureFlags = window.Vaadin.featureFlags || {};
 if (Object.keys(window.Vaadin.featureFlags).length === 0) {
-window.Vaadin.featureFlags.exampleFeatureFlag = false;
 window.Vaadin.featureFlags.collaborationEngineBackend = false;
-window.Vaadin.featureFlags.formFillerAddon = false;
-window.Vaadin.featureFlags.fullstackSignals = false;
 window.Vaadin.featureFlags.flowFullstackSignals = false;
-window.Vaadin.featureFlags.copilotExperimentalFeatures = false;
-window.Vaadin.featureFlags.masterDetailLayoutComponent = false;
-window.Vaadin.featureFlags.react19 = false;
 window.Vaadin.featureFlags.accessibleDisabledButtons = false;
+window.Vaadin.featureFlags.themeComponentStyles = false;
+window.Vaadin.featureFlags.copilotExperimentalFeatures = false;
+window.Vaadin.featureFlags.fullstackSignals = false;
+window.Vaadin.featureFlags.masterDetailLayoutComponent = false;
 window.Vaadin.featureFlags.layoutComponentImprovements = false;
 window.Vaadin.featureFlags.defaultAutoResponsiveFormLayout = false;
 };

--- a/demo-v24/frontend/styles/demo-styles.css
+++ b/demo-v24/frontend/styles/demo-styles.css
@@ -1,3 +1,5 @@
+@import '@vaadin/vaadin-lumo-styles/lumo.css';
+
 p {
     width: 250px;
     line-height: 80px;

--- a/demo-v24/pom.xml
+++ b/demo-v24/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <jetty.plugin.version>11.0.13</jetty.plugin.version>
+        <jetty.plugin.version>12.1.2</jetty.plugin.version>
     </properties>
 
     <dependencies>
@@ -84,8 +84,8 @@
         <plugins>
             <!-- We use jetty plugin, replace it with your favourite developing servlet container -->
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-maven-plugin</artifactId>
                 <version>${jetty.plugin.version}</version>
                 <configuration>
                     <systemProperties>

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,10 @@
     <packaging>pom</packaging>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>24.8.4</vaadin.version>
+        <vaadin.version>25.0.0-beta1</vaadin.version>
     </properties>
 
 </project>

--- a/superfields/pom.xml
+++ b/superfields/pom.xml
@@ -12,10 +12,10 @@
     <version>0.7.77-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>24.8.4</vaadin.version>
+        <vaadin.version>25.0.0-beta1</vaadin.version>
         <maven.jar.plugin.version>3.1.2</maven.jar.plugin.version>
         <javadoc.plugin.version>3.4.1</javadoc.plugin.version>
     </properties>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.github.mvysny.kaributesting</groupId>
             <artifactId>karibu-testing-v10</artifactId>
-            <version>2.0.2</version>
+            <version>2.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/superfields/src/main/resources/META-INF/resources/frontend/component-observer.js
+++ b/superfields/src/main/resources/META-INF/resources/frontend/component-observer.js
@@ -1,15 +1,9 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-
 /**
  * A web component that wraps Intersection Observer object and broadcasts events about changes.
  * This requires Flow and a corresponding server-side Java component to work properly.
  * Alternatively, make sure that this.$server.componentStatusChanged(String, double) is available.
  */
-export class ComponentObserver extends PolymerElement {
-
-    static get template() {
-        return html``;
-    }
+export class ComponentObserver extends HTMLElement {
 
     static get is() {
         return 'component-observer';

--- a/superfields/src/main/resources/META-INF/resources/frontend/date-pattern-mixin.js
+++ b/superfields/src/main/resources/META-INF/resources/frontend/date-pattern-mixin.js
@@ -10,7 +10,7 @@ export class DatePatternMixin {
                     console.error("SDP: no connector set, things will not work until it is set");
                     return;
                 }
-                datepicker.set('oldSetLocale', datepicker.$connector.setLocale);
+                datepicker.oldSetLocale = datepicker.$connector.setLocale;
                 datepicker.$connector.setLocale = locale => {
                         console.log('SDP: setting locale ' + locale);
                         datepicker.oldSetLocale(locale);
@@ -51,9 +51,12 @@ export class DatePatternMixin {
                 console.log("SDP: clearing date display pattern");
                 datepicker.i18n.dateDisplayPattern = '';
                 if (datepicker.noPatternParseAndFormat) {
-                    datepicker.set('i18n.parseDate', datepicker.noPatternParseAndFormat[0]);
-                    datepicker.set('i18n.formatDate', datepicker.noPatternParseAndFormat[1]);
-                    delete datepicker.noPatternParseAndFormat;
+                  datepicker.i18n = {
+                    ...datepicker.i18n,
+                    parseDate: datepicker.noPatternParseAndFormat[0],
+                    formatDate: datepicker.noPatternParseAndFormat[1],
+                  }
+                  delete datepicker.noPatternParseAndFormat;
                 }
             } else {
                 console.log('SDP: setting date display pattern to <' + displayPattern + '>');
@@ -61,30 +64,32 @@ export class DatePatternMixin {
                 if (!datepicker.noPatternParseAndFormat) {
                     datepicker.noPatternParseAndFormat = [datepicker.i18n.parseDate, datepicker.i18n.formatDate];
                 }
-                datepicker.set('i18n.formatDate', date => {
-                    const ddp = datepicker.i18n.dateDisplayPattern;
-                    const monthNames = datepicker.i18n.displayMonthNames;
-                    const startIndex = (ddp.length === 7 || ddp.length === 12) ? 1 : 0;
-                    console.log('SDP: custom formatting for ' + ddp);
-                    return [ddp.substr(startIndex, 2), ddp.substr(startIndex+2, 2), ddp.substr(startIndex+4, 2)].map(part => {
+                datepicker.i18n = {
+                    ...datepicker.i18n,
+                    formatDate(date) {
+                      const ddp = datepicker.i18n.dateDisplayPattern;
+                      const monthNames = datepicker.i18n.displayMonthNames;
+                      const startIndex = (ddp.length === 7 || ddp.length === 12) ? 1 : 0;
+                      console.log('SDP: custom formatting for ' + ddp);
+                      return [ddp.substr(startIndex, 2), ddp.substr(startIndex+2, 2), ddp.substr(startIndex+4, 2)].map(part => {
                         if (part === '0d') {
-                            return String(date.day).padStart(2, '0')
+                          return String(date.day).padStart(2, '0')
                         } else if (part === '_d') {
-                            return String(date.day)
+                          return String(date.day)
                         } else if (part === '0M') {
-                            return String(date.month + 1).padStart(2, '0')
+                          return String(date.month + 1).padStart(2, '0')
                         } else if (part === '_M') {
-                            return String(date.month + 1)
+                          return String(date.month + 1)
                         } else if (part === 'mM') {
-                            return monthNames[date.month]
+                          return monthNames[date.month]
                         } else if (part === '0y') {
-                            return date.year < 10 ? '0' + String(date.year) : String(date.year).substr(-2)
+                          return date.year < 10 ? '0' + String(date.year) : String(date.year).substr(-2)
                         } else if (part === '_y') {
-                            return String(date.year)
+                          return String(date.year)
                         }
-                    }).join(startIndex === 1 ? ddp[0] : '');
-                });
-                datepicker.set('i18n.parseDate', text => {
+                      }).join(startIndex === 1 ? ddp[0] : '');
+                    },
+                  parseDate(text) {
                     const ddp = datepicker.i18n.dateDisplayPattern;
                     const shortYear = ddp.indexOf('0y') !== -1;
                     const useMonthName = ddp.indexOf('mM') >= 0;
@@ -94,107 +99,108 @@ export class DatePatternMixin {
                     let date, month = today.getMonth(), year = today.getFullYear();
                     // this part is triggered when there is a separator
                     if (ddp.length === 7 || ddp.length === 12) {
-                        const parts = text.split(ddp[0]);
-                        if (parts.length === 3) {
-                            // d, M, y can be at index 2, 4 or 6 in the pattern
-                            year = parseInt(parts[(ddp.indexOf('y') / 2) - 1]);
-                            if (useMonthName) {
-                                const userInput = parts[(ddp.indexOf('M') / 2) - 1];
-                                month = monthNames.indexOf(monthNames.find(m => m.substring(0, userInput.length).localeCompare(userInput, undefined, {sensitivity: 'base'}) === 0));
-                                // this is here in case the locale was changed or the month was not found
-                                if (month === -1) {
-                                    month = parseInt(datepicker.value.substring(5, 7)) - 1;
-                                }
-                            } else {
-                                month = parseInt(parts[(ddp.indexOf('M') / 2) - 1]) - 1;
-                            }
-                            date = parseInt(parts[(ddp.indexOf('d') / 2) - 1]);
-                        } else if (parts.length === 2) {
-                            if (ddp.indexOf('d') < ddp.indexOf('M')) {
-                                date = parseInt(parts[0]);
-                                if (useMonthName) {
-                                    month = monthNames.indexOf(monthNames.find(m => m.substring(0, parts[1].length).localeCompare(parts[1], undefined, {sensitivity: 'base'}) === 0));
-                                    // this is here in case the locale was changed or the month was not found
-                                    if (month === -1) {
-                                        month = parseInt(datepicker.value.substring(5, 7)) - 1;
-                                    }
-                                } else {
-                                    month = parseInt(parts[1]) - 1;
-                                }
-                            } else {
-                                date = parseInt(parts[1]);
-                                if (useMonthName) {
-                                    month = monthNames.indexOf(monthNames.find(m => m.substring(0, parts[0].length).localeCompare(parts[0], undefined, {sensitivity: 'base'}) === 0));
-                                    // this is here in case the locale was changed or the month was not found
-                                    if (month === -1) {
-                                        month = parseInt(datepicker.value.substring(5, 7)) - 1;
-                                    }
-                                } else {
-                                    month = parseInt(parts[0]) - 1;
-                                }
-                            }
-                        } else if (parts.length === 1) {
-                            date = parseInt(parts[0]);
+                      const parts = text.split(ddp[0]);
+                      if (parts.length === 3) {
+                        // d, M, y can be at index 2, 4 or 6 in the pattern
+                        year = parseInt(parts[(ddp.indexOf('y') / 2) - 1]);
+                        if (useMonthName) {
+                          const userInput = parts[(ddp.indexOf('M') / 2) - 1];
+                          month = monthNames.indexOf(monthNames.find(m => m.substring(0, userInput.length).localeCompare(userInput, undefined, {sensitivity: 'base'}) === 0));
+                          // this is here in case the locale was changed or the month was not found
+                          if (month === -1) {
+                            month = parseInt(datepicker.value.substring(5, 7)) - 1;
+                          }
+                        } else {
+                          month = parseInt(parts[(ddp.indexOf('M') / 2) - 1]) - 1;
                         }
+                        date = parseInt(parts[(ddp.indexOf('d') / 2) - 1]);
+                      } else if (parts.length === 2) {
+                        if (ddp.indexOf('d') < ddp.indexOf('M')) {
+                          date = parseInt(parts[0]);
+                          if (useMonthName) {
+                            month = monthNames.indexOf(monthNames.find(m => m.substring(0, parts[1].length).localeCompare(parts[1], undefined, {sensitivity: 'base'}) === 0));
+                            // this is here in case the locale was changed or the month was not found
+                            if (month === -1) {
+                              month = parseInt(datepicker.value.substring(5, 7)) - 1;
+                            }
+                          } else {
+                            month = parseInt(parts[1]) - 1;
+                          }
+                        } else {
+                          date = parseInt(parts[1]);
+                          if (useMonthName) {
+                            month = monthNames.indexOf(monthNames.find(m => m.substring(0, parts[0].length).localeCompare(parts[0], undefined, {sensitivity: 'base'}) === 0));
+                            // this is here in case the locale was changed or the month was not found
+                            if (month === -1) {
+                              month = parseInt(datepicker.value.substring(5, 7)) - 1;
+                            }
+                          } else {
+                            month = parseInt(parts[0]) - 1;
+                          }
+                        }
+                      } else if (parts.length === 1) {
+                        date = parseInt(parts[0]);
+                      }
                     }
                     // there is no separator and thus by definition month and day are zero-based
                     // this means the pattern starts directly with day/month/year parts, each taking two characters
                     // it also means that the input is composed of parts with two eventually up to four characters
                     else {
-                        const dayOrder = Math.floor(ddp.indexOf('d') / 2);
-                        const monthOrder = Math.floor(ddp.indexOf('M') / 2);
-                        const yearOrder = Math.floor(ddp.indexOf('y') / 2);
-                       // if the length of the input is 1 or 2, it is a day
-                       if (text.length <= 2) {
-                           date = parseInt(text);
-                       }
-                       // length being 3 or 4 means there is a day and a month, in order defined by the pattern
-                       else if (text.length <= 4) {
-                           // day first
-                           if (dayOrder < monthOrder) {
-                               date = parseInt(text.substr(0, 2));
-                               month = parseInt(text.substr(2)) - 1;
-                           }
-                           // month first
-                           else {
-                               month = parseInt(text.substr(0, 2));
-                               date = parseInt(text.substr(2)) - 1;
-                           }
-                       }
-                       // length is more than 4 characters, which means there is also year involved
-                       else {
-                           let yearPosition = yearOrder * 2;
-                           let dayPosition = dayOrder * 2;
-                           let monthPosition = monthOrder * 2;
-                           // if year is full, month and day can potentially be offset by 2 extra characters
-                           if (!shortYear) {
-                               if (dayOrder > yearOrder)
-                                   dayPosition += 2;
-                               if (monthOrder > yearOrder)
-                                   monthPosition += 2;
-                           }
-                           date = parseInt(text.substr(dayPosition, 2));
-                           month = parseInt(text.substr(monthPosition, 2)) - 1;
-                           year = parseInt(text.substr(yearPosition, shortYear ? 2 : 4));
-                       }
+                      const dayOrder = Math.floor(ddp.indexOf('d') / 2);
+                      const monthOrder = Math.floor(ddp.indexOf('M') / 2);
+                      const yearOrder = Math.floor(ddp.indexOf('y') / 2);
+                      // if the length of the input is 1 or 2, it is a day
+                      if (text.length <= 2) {
+                        date = parseInt(text);
+                      }
+                      // length being 3 or 4 means there is a day and a month, in order defined by the pattern
+                      else if (text.length <= 4) {
+                        // day first
+                        if (dayOrder < monthOrder) {
+                          date = parseInt(text.substr(0, 2));
+                          month = parseInt(text.substr(2)) - 1;
+                        }
+                        // month first
+                        else {
+                          month = parseInt(text.substr(0, 2));
+                          date = parseInt(text.substr(2)) - 1;
+                        }
+                      }
+                      // length is more than 4 characters, which means there is also year involved
+                      else {
+                        let yearPosition = yearOrder * 2;
+                        let dayPosition = dayOrder * 2;
+                        let monthPosition = monthOrder * 2;
+                        // if year is full, month and day can potentially be offset by 2 extra characters
+                        if (!shortYear) {
+                          if (dayOrder > yearOrder)
+                            dayPosition += 2;
+                          if (monthOrder > yearOrder)
+                            monthPosition += 2;
+                        }
+                        date = parseInt(text.substr(dayPosition, 2));
+                        month = parseInt(text.substr(monthPosition, 2)) - 1;
+                        year = parseInt(text.substr(yearPosition, shortYear ? 2 : 4));
+                      }
                     }
                     // end of parsing stuff
                     // now, if short year is allowed (i.e. there is a description of default century and boundary year)
                     if (ddp.length === 12 || ddp.length === 11) {
-                        const boundaryYear = parseInt(ddp.substr(-2));
-                        const defaultCentury = parseInt(ddp.substr(-4, 2));
-                        if (year < boundaryYear) {
-                            year += (ddp[ddp.length-5] === '+' ? defaultCentury - 2 : defaultCentury - 1) * 100;
-                        } else if (year < 100) {
-                            year += (ddp[ddp.length-5] === '+' ? defaultCentury - 1 : defaultCentury - 2) * 100;
-                        }
-                        console.log("SDP: after fixing the year is "+year);
+                      const boundaryYear = parseInt(ddp.substr(-2));
+                      const defaultCentury = parseInt(ddp.substr(-4, 2));
+                      if (year < boundaryYear) {
+                        year += (ddp[ddp.length-5] === '+' ? defaultCentury - 2 : defaultCentury - 1) * 100;
+                      } else if (year < 100) {
+                        year += (ddp[ddp.length-5] === '+' ? defaultCentury - 1 : defaultCentury - 2) * 100;
+                      }
+                      console.log("SDP: after fixing the year is "+year);
                     }
                     // return result
                     if (date !== undefined) {
-                        return {day: date, month, year};
+                      return {day: date, month, year};
                     }
-                });
+                  }
+                }
             }
             // fixes #490 (only when some value is already there)
             if (datepicker.value !== undefined && datepicker.value.length > 0) {

--- a/superfields/src/main/resources/META-INF/resources/frontend/observed-field.js
+++ b/superfields/src/main/resources/META-INF/resources/frontend/observed-field.js
@@ -1,11 +1,6 @@
-import {html} from '@polymer/polymer/polymer-element.js';
 import {ComponentObserver} from "./component-observer";
 
 export class ObservedField extends ComponentObserver {
-    static get template() {
-        return html``;
-    }
-
     static get is() {
         return 'observed-field';
     }

--- a/superfields/src/main/resources/META-INF/resources/frontend/super-date-time-picker.js
+++ b/superfields/src/main/resources/META-INF/resources/frontend/super-date-time-picker.js
@@ -6,14 +6,14 @@ class SuperDateTimePicker extends DatePatternMixin.to(DateTimePicker) {
     static get is() { return 'super-date-time-picker'; }
 
     initPatternSetting(datepicker) {
-        super.initPatternSetting(datepicker.querySelector('vaadin-date-time-picker-date-picker'));
+        super.initPatternSetting(datepicker.querySelector('vaadin-date-picker'));
     }
 
     setDisplayPattern(datepicker, displayPattern) {
         // this method may be called by inner method that changes locale when the pattern is present
         // in such case, the datepicker object is the actual date picker, not the date-time picker container
         // see https://github.com/vaadin-miki/super-fields/issues/260
-        return super.setDisplayPattern(datepicker.tagName === 'VAADIN-DATE-TIME-PICKER-DATE-PICKER' ? datepicker : datepicker.querySelector('vaadin-date-time-picker-date-picker'), displayPattern);
+        return super.setDisplayPattern(datepicker.tagName === 'VAADIN-DATE-PICKER' ? datepicker : datepicker.querySelector('vaadin-date-picker'), displayPattern);
     }
 
 }

--- a/superfields/src/main/resources/META-INF/resources/frontend/unload-observer.js
+++ b/superfields/src/main/resources/META-INF/resources/frontend/unload-observer.js
@@ -1,16 +1,10 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-
 /**
  * A web component that listens to {@code beforeunload} events and sends them to server-side.
  * This requires Flow and a corresponding server-side Java component to work properly.
  * Alternatively, make sure that this.$server.unloadAttempted() is available.
  * Based on the code written by Kaspar Scherrer and Stuart Robinson: https://vaadin.com/forum/thread/17523194/unsaved-changes-detect-page-exit-or-reload
  */
-export class UnloadObserver extends PolymerElement {
-
-    static get template() {
-        return html``;
-    }
+export class UnloadObserver extends HTMLElement {
 
     static get is() {
         return 'unload-observer';
@@ -61,11 +55,6 @@ export class UnloadObserver extends PolymerElement {
         else {
             delete window.Vaadin.unloadObserver.query;
         }
-    }
-
-    static get properties() {
-        return {
-        };
     }
 }
 


### PR DESCRIPTION
I'm currently looking into Vaadin add-ons to identify some general challenges for add-on authors when upgrading to the upcoming Vaadin 25. I was able to get most of the things in this add-on working, so I figured I'll open a PR with what I have so far.

The changes include:
- Removing Polymer usage
  - Vaadin components in v25 are based on Lit instead of Polymer, and Polymer is not installed by default.
  - I updated `ComponentObserver` and `UnloadObserver` to not extend from `PolymerElement`. It looks like those did not depend on any Polymer API.
  - `date-picker-mixin.js` used `PolymerElement.set`, replaced that with just setting properties directly
- Other
  - Changed compiler version to 21, which is the minimum supported by Vaadin 25
  - Bumped Jetty to a version compatible with Java 21
  - Bumped karibu to newest version to avoid using a removed API in `VaadinSession`
  - Lumo is not loaded by default anymore. Updated demo styles to import the `lumo.css` stylesheet to load Lumo in the demos.

With that the component demos seem to work without any JS errors at least, though more testing by someone more experienced with this add-on would be encouraged. One exception is `ComponentObserver`, where initializing the IntersectionObserver throws an error for me: `TypeError: IntersectionObserver constructor: Double branch of (double or sequence<double>) is not a finite floating-point value.`. I don't think it's related to the other changes in this PR at least, might be something that was there before or is the result from some RPC change in Flow.

Edit: Let me add a disclaimer that I'll probably not continue working on this PR if it requires changes. Consider this a starting point, feel free to modify it or use the changes in your own PR. Thanks!