### PR TITLE
Update karibu-testing version to 2.7.0

### DIFF
--- a/superfields/pom.xml
+++ b/superfields/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.github.mvysny.kaributesting</groupId>
             <artifactId>karibu-testing-v10</artifactId>
-            <version>2.6.1</version>
+            <version>2.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Vaadin 25.1 branch, at least currently has backwards incompatible change that brakes Karibu Testing. This version works with both 25.1 and 25.0 series. No need for new version of super-fields, but helps to keep CIs happy.

Closes https://github.com/mstahv/vaadin-ecosystem-build/issues/11